### PR TITLE
fix "Comparison method violates its general contract" error

### DIFF
--- a/src/main/java/net/frostbyte/inventory/InventorySorter.java
+++ b/src/main/java/net/frostbyte/inventory/InventorySorter.java
@@ -112,10 +112,7 @@ public class InventorySorter implements ClientTickEvents.EndTick {
             return -1;
         }
         if (a.getItem().equals(b.getItem())) {
-            if (a.getCount() > b.getCount()) {
-                return -1;
-            }
-            return 1;
+            return Integer.compare(b.getCount(), a.getCount());
         }
         return Integer.compare(a.getItem().getName().getString().compareTo(b.getItem().getName().getString()), 0);
     }


### PR DESCRIPTION
I have been having occasional crashes when sort containers

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.base/java.util.TimSort.mergeLo(TimSort.java:781)
	at java.base/java.util.TimSort.mergeAt(TimSort.java:518)
	at java.base/java.util.TimSort.mergeCollapse(TimSort.java:448)
	at java.base/java.util.TimSort.sort(TimSort.java:245)
	at java.base/java.util.Arrays.sort(Arrays.java:1308)
	at java.base/java.util.ArrayList.sort(ArrayList.java:1804)
	at net.frostbyte.inventory.InventorySorter.getSortedStackArray(InventorySorter.java:129)
	at net.frostbyte.inventory.InventorySorter.sortStacks(InventorySorter.java:137)
	at net.frostbyte.inventory.InventorySorter.onEndTick(InventorySorter.java:51)
	at net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.lambda$static$2(ClientTickEvents.java:43)
	at net.minecraft.class_310.handler$zmc000$fabric-lifecycle-events-v1$onEndTick(class_310.java:6247)
	at net.minecraft.class_310.method_1574(class_310.java:2063)
	at net.minecraft.class_310.method_1523(class_310.java:1281)
	at net.minecraft.class_310.method_1514(class_310.java:888)
	at net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:470)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
```

I am not fully familiar with java but I believe that java is not happy that the return 0 case is not present in the code.
I tried the code change on a chest that kept crashing when I sort it and it seems to be working.